### PR TITLE
Update index.html

### DIFF
--- a/Program's_Contributed_By_Contributors/HTML Designs/Portfolio/index.html
+++ b/Program's_Contributed_By_Contributors/HTML Designs/Portfolio/index.html
@@ -222,7 +222,7 @@ but feel free to shoot me an email as well !</p>
     <form class="contact-form" action="">
         <label>Name :<br><input type="text" required name="" id="" placeholder="Your Name" /></label>
         <label>Email :<br><input type="email" name="" required id="" placeholder="Email" /></label>
-        <label>Message :<br><textarea type="text" name="" id="" placeholder="Message"> </textarea></label>
+        <label>Message :<br><textarea type="text" name="" id="" placeholder="Message"></textarea></label>
         <button type="submit"><span>Send</span><span><i class="fa-solid fa-arrow-right"></i></span></button>
     </form>
 


### PR DESCRIPTION




# Problem
Placeholder text was not showing up in the message box in the contact section of the website. (Due to extra whitespace)

# Solution
Fixing the whitespace.
Here is the link to answer on StackOverflow.
<a href="https://stackoverflow.com/questions/10186913/html5-textarea-placeholder-not-appearing">Question and answer</a>


## Changes proposed in this Pull Request :
-  `1.` Earlier (link to screenshot)
<a href="https://drive.google.com/file/d/1dUjDeU1e9MTTWD1nVb-cKaDkH5cbEBoo/view?usp=sharing">Placeholder not showing</a>
-  `2.`After removing whitespace in code
<a href="https://drive.google.com/file/d/15so59ekSD70jv--Uq4F-vnqHjg9PbQfG/view?usp=sharing">Placeholder showing</a>

-  `..`

## Other changes
-
