### PR TITLE
Updated contributors.css

### DIFF
--- a/css/contributors.css
+++ b/css/contributors.css
@@ -100,7 +100,7 @@ body {
 
 .container {
   position: relative;
-  color: var(--text);
+  color:#fc4670;
 }
 canvas {
   cursor: crosshair;


### PR DESCRIPTION

# Problem
- The div containing the heading CONTRIBUTORS and the paragraph below it are not clearly visible as they are written with black color on a nearly black background.

![image](https://user-images.githubusercontent.com/51708118/136739976-9718586b-b6b7-4705-9089-188d214b5404.png)


# Solution

![image](https://user-images.githubusercontent.com/51708118/136740011-8a4c04ff-8e64-4901-80fb-e9488dbdf003.png)


## Changes proposed in this Pull Request :
 `1.` Changed the Heading and paragraph color such that its clearly visible and matches with the theme of the webpage.

Issue Adressed:
#786