### PR TITLE
page not found bug

### DIFF
--- a/Contributors.html
+++ b/Contributors.html
@@ -366,6 +366,7 @@
       <a class="box-item" href="https://github.com/H-M-Noman123"><span>H-M-Noman123</span></a>
       <a class="box-item" href="https://github.com/barunipriyats"><span>Baruni Priya T S</span></a>
       <a class="box-item" href="https://github.com/anmolg84"><span>Anmol Gupta</span></a>
+      <a class="box-item" href="https://github.com/Pramila15"><span>Pramila Dalavai</span></a>
 
 
 


### PR DESCRIPTION
# Problem
- page Contributors in navbar not found
# Solution
- fix the link <a> tag

## Changes proposed in this Pull Request :
-  `1.`
-  `2.`
-  `..`

## Other changes
-
