### PR TITLE
Made changes to the contributor.css. Text visible in both modes

### DIFF
--- a/Contributors.html
+++ b/Contributors.html
@@ -366,7 +366,7 @@
       <a class="box-item" href="https://github.com/H-M-Noman123"><span>H-M-Noman123</span></a>
       <a class="box-item" href="https://github.com/barunipriyats"><span>Baruni Priya T S</span></a>
       <a class="box-item" href="https://github.com/anmolg84"><span>Anmol Gupta</span></a>
-
+      <a class="box-item" href="https://github.com/khushi-mishra0408"><span>Khushi Mishra</span></a>
 
 
 

--- a/css/contributors.css
+++ b/css/contributors.css
@@ -7,7 +7,7 @@
   --text: black;
   --box: #feeef2;
   --box-hover: #fe0c43;
-  --nav-color: white;
+  --nav-color: rgb(255, 230, 230);
   --footer-color: #ced4da;
 }
 [data-theme="dark"] {
@@ -19,6 +19,7 @@
   --box-hover: rgb(57 148 255);
   --nav-color: #1e1e28;
   --footer-color: #6c757d;
+  --container-text: #ffb3c6;
 }
 *,
 *::before,
@@ -100,8 +101,9 @@ body {
 
 .container {
   position: relative;
-  color: var(--text);
+  color: var(--container-text);
 }
+
 canvas {
   cursor: crosshair;
   display: block;


### PR DESCRIPTION

# Problem
- The text 'Contributors' in the container tag was not visible in the dark mode. 
# Solution
- Added color to the text when switched to dark mode. Now, it is visible in both modes.

## Changes proposed in this Pull Request :
-  in contributors.css - > root - > container-text color added
- in same - > container - > color changes according to the mode



