### PR TITLE
Fixed the overlapping of Back to top button with footer

### DIFF
--- a/Contributors.html
+++ b/Contributors.html
@@ -53,7 +53,7 @@
 
 
   <!-- Back-to-top Button -->
-  <button onclick="topFunction()" id="myBtn" title="Go to top">Back to Top</button>
+  <button onclick="topFunction()" id="myBtn" title="Go to top">↑</button>
 
   
   <button id="back-to-top-btn"><i class="fas fa-angle-double-up"></i></button>
@@ -367,6 +367,7 @@
       <a class="box-item" href="https://github.com/barunipriyats"><span>Baruni Priya T S</span></a>
       <a class="box-item" href="https://github.com/anmolg84"><span>Anmol Gupta</span></a>
       <a class="box-item" href="https://github.com/khushi-mishra0408"><span>Khushi Mishra</span></a>
+      <a class="box-item" href="https://github.com/poonervikas"><span>Vikas Pooner</span></a>
 
 
 


### PR DESCRIPTION
Fixed the overlapping of Back to top button with footer by changing the Back to top button text with "↑" icon.
