### PR TITLE
Transform property added to box-item on hover

### DIFF
--- a/Contributors.html
+++ b/Contributors.html
@@ -162,6 +162,7 @@
       <a class="box-item" href="https://github.com/gayathribuddhika"><span>Gayathri Buddhika</span></a>
       <a class="box-item" href="https://github.com/Triben-Choudhary"><span>Triben Choudhary</span></a>
       <a class="box-item" href="https://github.com/rajneeshk94"><span>Rajneesh Khare</span></a>
+      <a class="box-item" href="https://github.com/rashmi-thakurr"><span>Rashmi Thakur</span></a>
       <a class="box-item" href="https://github.com/milos5593"><span>Milos Vujinic</span></a>
       <a class="box-item" href="https://github.com/senshiii"><span>Sayan Das</span></a>
       <a class="box-item" href="https://github.com/Shagufta08"><span>Shagufta Iqbal</span></a>

--- a/css/contributors.css
+++ b/css/contributors.css
@@ -134,6 +134,7 @@ a:hover {
   color: #fe0c43;
   transition: 1s;
 }
+
 .moto:hover {
   text-decoration: underline;
   text-decoration-color: var(--gray);
@@ -149,6 +150,7 @@ a:hover {
   display: flex;
   flex-wrap: wrap;
 }
+
 
 .box-item {
   position: relative;
@@ -166,6 +168,14 @@ a:hover {
   overflow: hidden;
   white-space: nowrap;
   transition: color 0.5s ease-in;
+}
+
+.box-item:hover{
+  transform: scale(1.05);
+  transition: 1s;
+}
+.box-item:hover span{
+  color: navy;
 }
 
 @media (min-width: 768px) {

--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -1,13 +1,13 @@
 
 
 # Problem
-- 
+-On hover Box-Item grows in size now
 # Solution
--
+-transform property added to box-item on hover
 
 ## Changes proposed in this Pull Request :
--  `1.`
--  `2.`
+-  `1.`transform property added to box-item on hover
+-  `2.`on hover color of the contributors name changes to navy
 -  `..`
 
 ## Other changes


### PR DESCRIPTION

# Problem
- On hover Box-Item grows in size now, it didn't before
# Solution
-transform property added to box-item on hover

## Changes proposed in this Pull Request :
-  `1.`transform property added to box-item on hover
-  `2.`on hover color of the contributors name changes to navy
-  `..`

## Other changes
-
