### PR TITLE
made the <hr> visible in contributors.html in dark mode

### DIFF
--- a/Contributors.html
+++ b/Contributors.html
@@ -121,7 +121,7 @@
         </div>
       </div>
       <p class=" rubberBand delay-4s">Add yourself to the list if you contribute.</p>
-      <hr style="width:80%">
+      <hr style="width:80%" color="white">
     </div>
     <div class="box mx-auto">
 
@@ -371,8 +371,8 @@
       <a class="box-item" href="https://github.com/anmolg84"><span>Anmol Gupta</span></a>
       <a class="box-item" href="https://github.com/khushi-mishra0408"><span>Khushi Mishra</span></a>
       <a class="box-item" href="https://github.com/SayantanMaiti"><span>Sayantan Maiti</span></a>
-        <a class="box-item" href="https://github.com/Vishvesh-Codehunt"><span>Vishvesh Patel</span></a>
-
+      <a class="box-item" href="https://github.com/Vishvesh-Codehunt"><span>Vishvesh Patel</span></a>
+      <a class="box-item" href="https://github.com/napster-ansh"><span>Ansh Jain</span></a>
 
 
 


### PR DESCRIPTION

# Problem
- the horizontal rule is not visible in dark mode in contributors.html
# Solution
-changed the color for the same , so it is visible in both dark and light mode.

## Changes proposed in this Pull Request :
-  `1.`Added name to contributors.html
-  `2.`changed color for <hr> in contributors.html 
