### PR TITLE
GitHub profile added to contibutor.html

### DIFF
--- a/Contributors.html
+++ b/Contributors.html
@@ -139,6 +139,7 @@
       <a class="box-item" href="https://github.com/dwikychandra21"><span>Dwiky Chandra</span></a>
       <a class="box-item" href="https://github.com/ritesh2905"><span>Ritesh Kumar</span></a>
       <a class="box-item" href="https://github.com/xevenheaven"><span>Elysia Ong</span></a>
+      <a class="box-item" href="https://github.com/iamhsntariq05"><span>Hassan Tariq</span></a>
       <a class="box-item" href="https://github.com/facundof13"><span>Facundo</span></a>
       <a class="box-item" href="https://github.com/Aashik96"><span>Aashik Ahamed</span></a>
       <a class="box-item" href="https://github.com/Hrishabh5"><span>Hrishabh Jain</span></a>


### PR DESCRIPTION

# Problem
-On hover Box-Item grows in size now
# Solution
-transform property added to box-item on hover

## Changes proposed in this Pull Request :
-  `1.`transform property added to box-item on hover
-  `2.`on hover color of the contributors name changes to navy
-  `..`

## Other changes
-
