### PR TITLE
Create default-args.rs

### DIFF
--- a/Program's_Contributed_By_Contributors/Rust_Programs/default-args.rs
+++ b/Program's_Contributed_By_Contributors/Rust_Programs/default-args.rs
@@ -1,0 +1,28 @@
+// Source: https://www.sudipg.com.np/posts/default-argument-rust-using-macro/#-solution
+
+macro_rules! print_this {
+    ($a: expr) => {
+        print_this_raw($a, 0, 0);
+    };
+    ($a: expr, $b: expr) => {
+        print_this_raw($a, $b, 0);
+    };
+    ($a: expr, $b: expr, $c: expr) => {
+        print_this_raw($a, $b, $c);
+    };
+}
+
+fn print_this_raw(a: i32, b: i32, c: i32) {
+    println!("a = {} >> b = {} >> c = {}", a, b, c);
+}
+
+fn main() {
+    // a = 10, b = 0, c = 0
+    print_this!(10);
+
+    // a = 10, b = 20, c = 0
+    print_this!(10, 20);
+
+    // a = 10, b = 20, c = 30
+    print_this!(10, 20, 30);
+}


### PR DESCRIPTION
# Problem
No any rust programs yet
# Solution
Add a rust program that shows default argument like interface

## Changes proposed in this Pull Request :
- Create a Rust_Programs folder.
- Create Rust_Programs/default-args.rs file
- Write code that show default argument like interface. As rust doesn't support default argument by default make use of macros to achieve so
