### PR TITLE
Create flaten_binary_tree.cpp

### DIFF
--- a/Program's_Contributed_By_Contributors/C++ Programs/linkedlist/flaten_binary_tree.cpp
+++ b/Program's_Contributed_By_Contributors/C++ Programs/linkedlist/flaten_binary_tree.cpp
@@ -1,0 +1,26 @@
+class Solution {
+public:
+    //TO FIND rightmost child
+    TreeNode* rightmost(TreeNode* root){
+        if (root->right==NULL) return root;
+        return rightmost(root->right);
+    }
+    
+    void flatten(TreeNode* root) {
+        if (root==NULL) return;
+        TreeNode* nextright;
+        TreeNode* rightMOST;
+        
+        while (root){
+            
+            if (root->left){
+                rightMOST = rightmost(root->left);
+                nextright = root->right;
+                root->right = root->left;
+                root->left=NULL;
+                rightMOST->right=nextright;
+            }
+            root=root->right;
+        }
+    }
+};


### PR DESCRIPTION
Issue#2085



# Problem
-
Given the root of a binary tree, flatten the tree into a "linked list":

-The "linked list" should use the same TreeNode class where the right child pointer points to the next node in the list and the left child pointer is always null.
-The "linked list" should be in the same order as a [pre-order traversal](https://en.wikipedia.org/wiki/Tree_traversal#Pre-order,_NLR) of the binary tree.
# Solution
-

## Changes proposed in this Pull Request :
-  `1.`<!-- transform property added to box-item on hover -->
-  `..`

## Other changes
-
