### PR TITLE
Added 'alt' attribute in img tag

### DIFF
--- a/contributors/contributorsList.js
+++ b/contributors/contributorsList.js
@@ -2019,6 +2019,7 @@ contributors = [
     fullname: "Alejandro Armenta",
     username: "https://github.com/alexanderNWO",
   },
+  {
     id: 417,
     fullname: "Krish Katyal",
     username: "https://github.com/krishkatyal",
@@ -2034,5 +2035,10 @@ contributors = [
     fullname: "Amit Kumar",
     username: "https://github.com/amit-kumar",
   },
+  {
+    id:420,
+    fullname:"Auro S.",
+    username:"https://github.com/aurocodes",
+  }
 
 ];

--- a/index.html
+++ b/index.html
@@ -214,7 +214,7 @@
                 render(contributors)
                 document.querySelectorAll('a.box-item').forEach(con => {
                     // console.log(con.href)
-                    con.innerHTML += `<img loading="lazy" src="https://avatars.githubusercontent.com/${con.href.split('https://github.com/')[1]}">`
+                    con.innerHTML += `<img alt="avatar" loading="lazy" src="https://avatars.githubusercontent.com/${con.href.split('https://github.com/')[1]}">`
                 })
                 document.getElementById('loading').setAttribute('hidden', true)
                 if (initialContributorsNumber >= contributors.length) {
@@ -229,7 +229,7 @@
 
         document.querySelectorAll('a.box-item').forEach(con => {
             // console.log(con.href)
-            con.innerHTML += `<img loading="lazy" src="https://avatars.githubusercontent.com/${con.href.split('https://github.com/')[1]}">`
+            con.innerHTML += `<img alt="avatar" loading="lazy" src="https://avatars.githubusercontent.com/${con.href.split('https://github.com/')[1]}">`
         })
 
         searchbox.addEventListener('keyup', async (e) => {
@@ -267,7 +267,7 @@
 
             document.querySelectorAll('a.box-item').forEach(con => {
                 // console.log(con.href)
-                con.innerHTML += `<img loading="lazy" src="https://github.com/${con.href.split('https://github.com/')[1]}.png">`
+                con.innerHTML += `<img alt="github" loading="lazy" src="https://github.com/${con.href.split('https://github.com/')[1]}.png">`
             })
 
             document.getElementById('loading').setAttribute('hidden', true)


### PR DESCRIPTION
added alt attribute in img tag, missing alt attribute can be cause of warnings



# Problem
-alt attribute missing from img tag

# Solution
- added alt attribute in all img tags

## Changes proposed in this Pull Request :
-  `1.`<!-- transform property added to box-item on hover -->
-  `..`

## Other changes
-
