### PR TITLE
Fix Duplicate Instagram Keys in Menu Object

### DIFF
--- a/scripts/menu.js
+++ b/scripts/menu.js
@@ -16,7 +16,7 @@ const menu = {
       'text': 'Instagram Connect',
       'href': 'https://instagram.com/fineanmol'
     },
-    'Instagram': {
+    'InstagramAlt': {
       'text': 'Connect on <i class="fa fa-instagram" style="font-size:22px"></i>',
       'href': 'https://instagram.com/fineanmol'
     },


### PR DESCRIPTION
Fixes #7419 

This commit resolves the issue of duplicate Instagram keys in the menu object within menu.js. One of the Instagram keys has been renamed to "InstagramAlt" to ensure both Instagram links are preserved in the navigation menu. This change enhances user access to social media links and improves overall functionality.

# Problem
The problem with this issue is the presence of two entries for Instagram in the menu object, which causes one to overwrite the other. This results in the loss of access to one of the Instagram links, negatively impacting user experience and functionality. By addressing this duplication, the navigation menu can effectively present all intended social media links, ensuring users can access them without issues.

# Solution
we resolved the problem of duplicate Instagram keys in the menu object. The solution involved renaming one of the keys to InstagramAlt to prevent overwriting and ensure both links were accessible in the navigation menu. This change maintains the menu's functionality and enhances the user experience by providing easy access to all social media links.


## Changes Proposed

- `1.` Renamed a Duplicate Key: One of the Instagram keys in the menu object was renamed to InstagramAlt to avoid overwriting and ensure both links are preserved.
-`2.` Maintained Functionality: This adjustment helps retain the intended functionality of the navigation menu by ensuring all social media links are accessible.
