### PR TITLE
Fix: remove extra bottom padding from body (Issue #8028)

### DIFF
--- a/css/contributors.css
+++ b/css/contributors.css
@@ -62,7 +62,7 @@ body {
   flex-direction: column;
   margin: 0;
   min-height: 100vh;
-  padding: 0 0 1.5rem;
+  padding: 0; /*Fixed padding issue*/
   position: relative;
   font-family: "JetBrains Mono", monospace;
   font-size: 13px;


### PR DESCRIPTION
This PR fixes #8028 by removing unnecessary bottom padding from the body so that the footer touches the bottom.