### PR TITLE
Implement Reverse Nodes in K-Group for Linked List

### DIFF
--- a/ReverseNodeKGroupSize.java
+++ b/ReverseNodeKGroupSize.java
@@ -1,0 +1,72 @@
+public class ReverseNodeKGroupSize {
+    private static Node CovertArr2LL(int[] arr) {
+        Node head = new Node(arr[0]);
+        Node tmp = head;
+        for (int i = 1; i < arr.length; i++) {
+            tmp.next = new Node(arr[i]);
+            tmp = tmp.next;
+        }
+        return head;
+    }
+    private static void printLL(Node head) {
+        Node tmp = head; 
+        while (tmp != null) {
+            System.out.print(tmp.data + " ");
+            tmp = tmp.next;
+        }
+        System.out.println();
+    }
+
+
+    // TC -> O(N) + O(N)
+    // SC -> O(1)
+    private static Node reverseLL(Node head) {
+        Node prev = null;
+        Node curr = head;
+        while (curr != null) {
+            Node next = curr.next;
+            curr.next = prev;
+            prev = curr;
+            curr = next;
+        }
+        return prev;
+    }
+    private static Node findKthNode(Node head, int k) {
+        k -= 1;
+        while (head != null && k > 0) {
+            k--;
+            head = head.next;
+        }
+        return head;
+    }
+    public static Node reverseKGroup(Node head, int k) {
+        Node tmp = head;
+        Node prevNode = null;
+        while (tmp != null) {
+            Node kthNode = findKthNode(tmp,k);
+            if (kthNode == null) {
+                if (prevNode != null) prevNode.next = tmp;
+                break;
+            }
+            Node nxtNode = kthNode.next;
+            kthNode.next = null;
+            reverseLL(tmp);
+            if (tmp == head) {
+                head = kthNode;
+            }
+            else prevNode.next = kthNode;
+            prevNode = tmp;
+            tmp = nxtNode;
+        }
+        return head;
+    }
+    public static void main(String[] args) {
+        int[] arr = {1,2,3,4,5,6,7,8};
+        Node head = CovertArr2LL(arr);
+        int k = 3;
+        printLL(head);
+
+        head = reverseKGroup(head, k);
+        printLL(head);
+    }
+}


### PR DESCRIPTION
## 🌀 Reverse Nodes in K-Group (Linked List)

### ✅ Overview
This PR introduces a solution to reverse a linked list in groups of size **k**. The function processes the linked list in segments of `k` nodes, reverses each such segment, and connects them back together. If the remaining nodes are fewer than `k`, they are left as-is.

This technique is commonly used in linked list manipulation problems and helps in understanding pointer rearrangement, group-wise reversal logic, and linked list traversal patterns.

---

### 🎯 Key Functionality

| Method Name | Purpose |
|------------|---------|
| `CovertArr2LL()` | Converts an integer array into a singly linked list |
| `printLL()` | Prints the linked list |
| `reverseLL()` | Reverses an entire linked list (used as helper method) |
| `findKthNode()` | Locates the k-th node from a given starting node |
| `reverseKGroup()` | Reverses the linked list in groups of size `k` (main logic) |

---

### ⚙️ How the Algorithm Works

1. Start with the head of the linked list.
2. Identify the **k-th node** from the current position using `findKthNode()`.
3. If less than `k` nodes remain, leave them unchanged and stop.
4. Otherwise:
   - Temporarily break the list after the `k-th` node.
   - Reverse this segment using `reverseLL()`.
   - Reconnect the reversed segment back into the list.
5. Move forward to the next segment and repeat until the end of the list is reached.

---

### 🧠 Complexity Analysis

| Complexity | Value | Notes |
|----------|--------|------|
| Time | **O(N)** | Each node is visited and possibly reversed once |
| Space | **O(1)** | Reversal is performed in-place using pointer manipulation |

---