### PR TITLE
ci: simplify conflict hint comment and post as fineanmol

### DIFF
--- a/.github/workflows/pr-automation.yml
+++ b/.github/workflows/pr-automation.yml
@@ -11,12 +11,11 @@ permissions:
 jobs:
   hint:
     runs-on: ubuntu-latest
-    if: github.repository == 'fineanmol/Hacktoberfest2025'
     steps:
       - name: Comment on conflicting PRs
         uses: actions/github-script@v7
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          github-token: ${{ secrets.AUTOMERGE_TOKEN }}
           script: |
             const pr = context.payload.pull_request;
             const { data: fresh } = await github.rest.pulls.get({
@@ -29,7 +28,7 @@ jobs:
               return;
             }
 
-            const marker = '<!-- hacktoberfest-conflict-hint -->';
+            const marker = '<!-- merge-conflict-hint -->';
             const { data: comments } = await github.rest.issues.listComments({
               owner: context.repo.owner,
               repo: context.repo.repo,
@@ -41,16 +40,15 @@ jobs:
               return;
             }
 
+            const baseBranch = pr.base.ref;
             const body = [
               marker,
               '🔧 **Merge conflicts detected**',
               '',
               'To fix:',
-              '1. `git fetch upstream` and merge latest `master` into your branch',
+              `1. \`git fetch upstream\` and merge latest \`${baseBranch}\` into your branch`,
               '2. Resolve conflicts locally',
               '3. Push your branch — we will merge once it is clean',
-              '',
-              '**Contributor lists:** keep **Anmol Agarwal (fineanmol)** as the first entry; add new contributors at the **end** of `contributors/contributorsList1.js` or `contributors/contributorslist.js`.',
             ].join('\n');
 
             await github.rest.issues.createComment({


### PR DESCRIPTION
Removes contributor-list instructions. Uses AUTOMERGE_TOKEN so comments show as fineanmol.