### PR TITLE
ci: rename workflow display names for clarity

### DIFF
--- a/.github/workflows/auto-comment.yml
+++ b/.github/workflows/auto-comment.yml
@@ -1,5 +1,4 @@
-name: Auto Comment
-
+name: Comment · Star repo reminder
 on:
   pull_request_target:
     types: [opened, reopened, synchronize]

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,5 +1,4 @@
-name: Deploy static content to Pages
-
+name: Deploy · GitHub Pages
 on:
   push:
     branches: [master]

--- a/.github/workflows/pr-automation.yml
+++ b/.github/workflows/pr-automation.yml
@@ -1,5 +1,4 @@
-name: PR merge hints
-
+name: Comment · PR merge conflict help
 on:
   pull_request_target:
     types: [opened, synchronize, reopened]

--- a/.github/workflows/validate-site.yml
+++ b/.github/workflows/validate-site.yml
@@ -1,5 +1,4 @@
-name: Validate site on PR
-
+name: CI · Validate site
 on:
   pull_request:
     types: [opened, synchronize, reopened]


### PR DESCRIPTION
## Summary
- Renames GitHub Actions workflow display names to a consistent **Category · Description** pattern
- Makes it easy to scan the Actions tab and know what each workflow does

## Naming scheme
| Category | Workflows |
|----------|-----------|
| **Comment** | PR merge conflict help, Star repo reminder |
| **CI** | Validate package / site / scripts |
| **Deploy** | GitHub Pages |
| **Release** | Publish to npm |
| **Dependabot** | Auto-merge PRs |

## Test plan
- [ ] Workflows still trigger on the same events
- [ ] Dependabot auto-merge still waits for `CI · Validate package` (npm repos)